### PR TITLE
Updated xtensa links as have been moved

### DIFF
--- a/package_digistump_index.json
+++ b/package_digistump_index.json
@@ -617,35 +617,35 @@
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "http://arduino.esp8266.com/win32-xtensa-lx106-elf-gb404fb9-2.tar.gz",
+              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/win32-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "archiveFileName": "win32-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "checksum": "SHA-256:10476b9c11a7a90f40883413ddfb409f505b20692e316c4e597c4c175b4be09c",
               "size": "153527527"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "http://arduino.esp8266.com/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
+              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "archiveFileName": "osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "checksum": "SHA-256:0cf150193997bd1355e0f49d3d49711730035257bc1aee1eaaad619e56b9e4e6",
               "size": "35385382"
             },
             {
               "host": "i386-apple-darwin",
-              "url": "http://arduino.esp8266.com/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
+              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "archiveFileName": "osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
               "checksum": "SHA-256:0cf150193997bd1355e0f49d3d49711730035257bc1aee1eaaad619e56b9e4e6",
               "size": "35385382"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "http://arduino.esp8266.com/linux64-xtensa-lx106-elf-gb404fb9.tar.gz",
+              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/linux64-xtensa-lx106-elf-gb404fb9.tgz",
               "archiveFileName": "linux64-xtensa-lx106-elf-gb404fb9.tar.gz",
               "checksum": "SHA-256:46f057fbd8b320889a26167daf325038912096d09940b2a95489db92431473b7",
               "size": "30262903"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "http://arduino.esp8266.com/linux32-xtensa-lx106-elf.tar.gz",
+              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/linux32-xtensa-lx106-elf.tar.gz",
               "archiveFileName": "linux32-xtensa-lx106-elf.tar.gz",
               "checksum": "SHA-256:b24817819f0078fb05895a640e806e0aca9aa96b47b80d2390ac8e2d9ddc955a",
               "size": "32734156"


### PR DESCRIPTION
Now hosted on GitHub rather than on a standalone server