### PR TITLE
Update package_digistump_index.json

### DIFF
--- a/package_digistump_index.json
+++ b/package_digistump_index.json
@@ -46,11 +46,6 @@
           ],
           "toolsDependencies": [
             {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
               "packager": "digistump",
               "name": "micronucleus",
               "version": "2.0a4"


### PR DESCRIPTION
Removed avr-gcc toolsDependency because it downloads an unsupported 32-bits version of avr-gcc. Now the avr-gcc that is packaged with Arduino is used.