### PR TITLE
Update package_digistump_index.json for 64-bit AVR 7.3.0

### DIFF
--- a/package_digistump_index.json
+++ b/package_digistump_index.json
@@ -48,7 +48,7 @@
             {
               "packager": "arduino",
               "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
+              "version": "7.3.0-atmel3.6.1-arduino7"
             },
             {
               "packager": "digistump",


### PR DESCRIPTION
Changed reference to old 32-bit AVR GCC (4.8.1) to new 64-bit GCC 7.3.0-atmel3.6.1-arduino7.
This should exist if you have updated "Arduino AVR Boards" in Boards Manager to 1.8.5